### PR TITLE
Add migration to update streams table with games and video_id

### DIFF
--- a/migrations/20250302230956_fix_streams.down.sql
+++ b/migrations/20250302230956_fix_streams.down.sql
@@ -1,0 +1,9 @@
+-- Remove the new columns
+ALTER TABLE streams
+DROP COLUMN video_id,
+DROP COLUMN games;
+
+-- Add back the old columns
+ALTER TABLE streams
+ADD COLUMN event_log TEXT,
+ADD COLUMN video_url TEXT;

--- a/migrations/20250302230956_fix_streams.up.sql
+++ b/migrations/20250302230956_fix_streams.up.sql
@@ -1,0 +1,9 @@
+-- Drop the event_log and video_url columns
+ALTER TABLE streams
+DROP COLUMN IF EXISTS event_log_url,
+DROP COLUMN IF EXISTS video_url;
+
+-- Add the new columns
+ALTER TABLE streams
+ADD COLUMN games TEXT[] NOT NULL DEFAULT '{}',
+ADD COLUMN video_id TEXT REFERENCES videos(id) ON DELETE SET NULL;


### PR DESCRIPTION
Additionally, this also drops the `event_log` and `video_url` columns. `event_log` isn't necessary because of the way we get events via NATS now. `video_url` was effectively replaced by `video_id`, which is a foreign key to `videos`